### PR TITLE
Make add_widget no longer an alias, but call addWidget instead

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,9 +9,15 @@
 - ``waitExposed`` and ``waitActive`` now have a default timeout of 5s instead of 1s, in order to match the default
   timeouts Qt uses in the underlying QTest methods.
 - When the ``-s`` (``--capture=no``) argument is passed to pytest, Qt log capturing is now disabled as well.
+- PEP-8 aliases (``add_widget``, ``wait_active``, etc) are no longer just simple
+  assignments to the methods, but they are real methods which call the normal
+  implementations. This makes subclasses work as expected, instead of having to
+  duplicate the assignment. Thanks `@oliveira-mauricio`_ for the PR.
 
 .. _#222: https://github.com/pytest-dev/pytest-qt/pull/222
+.. _#326: https://github.com/pytest-dev/pytest-qt/pull/326
 .. _@karlch: https://github.com/karlch
+.. _@oliveira-mauricio: https://github.com/oliveira-mauricio
 
 3.3.0 (2019-12-07)
 ------------------

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -170,7 +170,8 @@ class QtBot:
             raise TypeError("Need to pass a QWidget to addWidget!")
         _add_widget(self._request.node, widget, before_close_func=before_close_func)
 
-    add_widget = addWidget  # pep-8 alias
+    def add_widget(self, widget, **kwargs):  # pep-8 style
+        self.addWidget(widget, **kwargs)
 
     def waitActive(self, widget, timeout=5000):
         """

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -170,9 +170,6 @@ class QtBot:
             raise TypeError("Need to pass a QWidget to addWidget!")
         _add_widget(self._request.node, widget, before_close_func=before_close_func)
 
-    def add_widget(self, widget, **kwargs):  # pep-8 style
-        self.addWidget(widget, **kwargs)
-
     def waitActive(self, widget, timeout=5000):
         """
         Context manager that waits for ``timeout`` milliseconds or until the window is active.
@@ -202,8 +199,6 @@ class QtBot:
         return _WaitWidgetContextManager(
             "qWaitForWindowActive", "activated", widget, timeout
         )
-
-    wait_active = waitActive  # pep-8 alias
 
     def waitExposed(self, widget, timeout=5000):
         """
@@ -235,8 +230,6 @@ class QtBot:
             "qWaitForWindowExposed", "exposed", widget, timeout
         )
 
-    wait_exposed = waitExposed  # pep-8 alias
-
     def waitForWindowShown(self, widget):
         """
         Waits until the window is shown in the screen. This is mainly useful for asynchronous
@@ -254,8 +247,6 @@ class QtBot:
             return qt_api.QtTest.QTest.qWaitForWindowExposed(widget)
         else:
             return qt_api.QtTest.QTest.qWaitForWindowShown(widget)
-
-    wait_for_window_shown = waitForWindowShown  # pep-8 alias
 
     def stopForInteraction(self):
         """
@@ -343,8 +334,6 @@ class QtBot:
         if signal is not None:
             blocker.connect(signal)
         return blocker
-
-    wait_signal = waitSignal  # pep-8 alias
 
     def waitSignals(
         self,
@@ -436,8 +425,6 @@ class QtBot:
             blocker.add_signals(signals)
         return blocker
 
-    wait_signals = waitSignals  # pep-8 alias
-
     def wait(self, ms):
         """
         .. versionadded:: 1.9
@@ -471,8 +458,6 @@ class QtBot:
         with spy, self.waitSignal(signal, timeout=wait, raising=False):
             yield
         spy.assert_not_emitted()
-
-    assert_not_emitted = assertNotEmitted  # pep-8 alias
 
     def waitUntil(self, callback, timeout=1000):
         """
@@ -543,8 +528,6 @@ class QtBot:
                     raise TimeoutError(timeout_msg)
             self.wait(10)
 
-    wait_until = waitUntil  # pep-8 alias
-
     def waitCallback(self, timeout=1000, raising=None):
         """
         .. versionadded:: 3.1
@@ -585,8 +568,6 @@ class QtBot:
         raising = self._should_raise(raising)
         blocker = CallbackBlocker(timeout=timeout, raising=raising)
         return blocker
-
-    wait_callback = waitCallback  # pep-8 alias
 
     @contextlib.contextmanager
     def captureExceptions(self):
@@ -656,6 +637,35 @@ class QtBot:
             method = create_qtest_proxy_method(method_name)
             if method is not None:
                 setattr(cls, method_name, method)
+
+    # pep-8 aliases
+
+    def add_widget(self, *args, **kwargs):
+        return self.addWidget(*args, **kwargs)
+
+    def wait_active(self, *args, **kwargs):
+        return self.waitActive(*args, **kwargs)
+
+    def wait_exposed(self, *args, **kwargs):
+        return self.waitExposed(*args, **kwargs)
+
+    def wait_for_window_shown(self, *args, **kwargs):
+        return self.waitForWindowShown(*args, **kwargs)
+
+    def wait_signal(self, *args, **kwargs):
+        return self.waitSignal(*args, **kwargs)
+
+    def wait_signals(self, *args, **kwargs):
+        return self.waitSignals(*args, **kwargs)
+
+    def assert_not_emitted(self, *args, **kwargs):
+        return self.assertNotEmitted(*args, **kwargs)
+
+    def wait_until(self, *args, **kwargs):
+        return self.waitUntil(*args, **kwargs)
+
+    def wait_callback(self, *args, **kwargs):
+        return self.waitCallback(*args, **kwargs)
 
 
 # provide easy access to exceptions to qtbot fixtures

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -535,3 +535,26 @@ def test_addwidget_typeerror(testdir, qtbot):
     obj = qt_api.QtCore.QObject()
     with pytest.raises(TypeError):
         qtbot.addWidget(obj)
+
+
+def test_add_widget_calls_addWidget(request):
+    """
+    add_widget should call addWidget for subclasses too. If we had a subclass that overwrites addWidget
+    but not the add_widget, calls to it would be mapped to the super class method instead of its own.
+    """
+    from pytestqt.qtbot import QtBot
+
+    calls = []
+
+    class CustomQtBot(QtBot):
+        def addWidget(self, widget, *, before_func_close=None):
+            calls.append(True)
+
+    custom_qtbot = CustomQtBot(request)
+
+    widget = qt_api.QWidget()
+    custom_qtbot.addWidget(widget)
+    assert calls == [True]
+
+    custom_qtbot.add_widget(widget)
+    assert calls == [True, True]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -535,26 +535,3 @@ def test_addwidget_typeerror(testdir, qtbot):
     obj = qt_api.QtCore.QObject()
     with pytest.raises(TypeError):
         qtbot.addWidget(obj)
-
-
-def test_add_widget_calls_addWidget(request):
-    """
-    add_widget should call addWidget for subclasses too. If we had a subclass that overwrites addWidget
-    but not the add_widget, calls to it would be mapped to the super class method instead of its own.
-    """
-    from pytestqt.qtbot import QtBot
-
-    calls = []
-
-    class CustomQtBot(QtBot):
-        def addWidget(self, widget, *, before_func_close=None):
-            calls.append(True)
-
-    custom_qtbot = CustomQtBot(request)
-
-    widget = qt_api.QWidget()
-    custom_qtbot.addWidget(widget)
-    assert calls == [True]
-
-    custom_qtbot.add_widget(widget)
-    assert calls == [True, True]


### PR DESCRIPTION
We use a subclass of QtBot with a custom `addWidget`. However, when using `add_widget`, which was not redefined in our subclass, it would call the alias in QtBot, calling the parent's `addWidget`, without our customizations, leading to undesired behavior.

Instead of using an alias, I've added an implementation that works for subclasses as well.